### PR TITLE
[FIX] custom_background: properly inherit _run_wkhtmltopdf

### DIFF
--- a/custom_background/models/report.py
+++ b/custom_background/models/report.py
@@ -2,40 +2,17 @@
 import base64
 import logging
 import os
-import subprocess
 import tempfile
 from contextlib import closing
 
 from PyPDF2 import PdfFileReader, PdfFileWriter
-from reportlab.graphics.barcode import createBarcodeDrawing
 
 from odoo import api, fields, models
 from odoo.exceptions import UserError
-from odoo.tools.misc import find_in_path
 from odoo.tools.safe_eval import safe_eval
 from odoo.tools.translate import _
 
-try:
-    createBarcodeDrawing(
-        "Code128",
-        value="foo",
-        format="png",
-        width=100,
-        height=100,
-        humanReadable=1,
-    ).asString("png")
-except Exception:
-    pass
-
-
-# --------------------------------------------------------------------------
-# Helpers
-# --------------------------------------------------------------------------
 _logger = logging.getLogger(__name__)
-
-
-def _get_wkhtmltopdf_bin():
-    return find_in_path("wkhtmltopdf")
 
 
 class ReportBackgroundLine(models.Model):
@@ -241,109 +218,23 @@ class IrActionsReport(models.Model):
 
     @api.model
     def _run_wkhtmltopdf(
-        self,
-        bodies,
-        header=None,
-        footer=None,
-        landscape=False,
-        specific_paperformat_args=None,
-        set_viewport_size=False,
+        self, bodies, header=None, footer=None, landscape=False,
+        specific_paperformat_args=None, set_viewport_size=False,
     ):
-        """Execute wkhtmltopdf as a subprocess in order to convert html given
-        in input into a pdf document.
-
-        :param bodies: The html bodies of the report, one per page.
-        :param header: The html header of the report containing all headers.
-        :param footer: The html footer of the report containing all footers.
-        :param landscape: Force the pdf to be rendered under a landscape
-                        format.
-        :param specific_paperformat_args: dict of prioritized paperformat
-                                        arguments.
-        :param set_viewport_size: Enable a viewport sized '1024x1280' or
-                                '1280x1024' depending of landscape arg.
-        :return: Content of the pdf as a string
-        """
-
-        # call default odoo standard function of paperformat #19896
-        # https://github.com/odoo/odoo/blob/13.0/odoo/addons/base/models
-        # /ir_actions_report.py#L243
-        paperformat_id = self.get_paperformat()
-
-        # Build the base command args for wkhtmltopdf bin
-        command_args = self._build_wkhtmltopdf_args(
-            paperformat_id,
-            landscape,
+        pdf_content = super()._run_wkhtmltopdf(
+            bodies, header=header,footer=footer, landscape=landscape,
             specific_paperformat_args=specific_paperformat_args,
             set_viewport_size=set_viewport_size,
         )
-
-        files_command_args = []
         temporary_files = []
-        if header:
-            head_file_fd, head_file_path = tempfile.mkstemp(
-                suffix=".html", prefix="report.header.tmp."
-            )
-            with closing(os.fdopen(head_file_fd, "wb")) as head_file:
-                head_file.write(header.encode())
-            temporary_files.append(head_file_path)
-            files_command_args.extend(["--header-html", head_file_path])
-        if footer:
-            foot_file_fd, foot_file_path = tempfile.mkstemp(
-                suffix=".html", prefix="report.footer.tmp."
-            )
-            with closing(os.fdopen(foot_file_fd, "wb")) as foot_file:
-                foot_file.write(footer.encode())
-            temporary_files.append(foot_file_path)
-            files_command_args.extend(["--footer-html", foot_file_path])
-
-        paths = []
-        for i, body in enumerate(bodies):
-            prefix = "%s%d." % ("report.body.tmp.", i)
-            body_file_fd, body_file_path = tempfile.mkstemp(
-                suffix=".html", prefix=prefix
-            )
-            with closing(os.fdopen(body_file_fd, "wb")) as body_file:
-                body_file.write(body.encode())
-            paths.append(body_file_path)
-            temporary_files.append(body_file_path)
-
-        pdf_report_fd, pdf_report_path = tempfile.mkstemp(
-            suffix=".pdf", prefix="report.tmp."
-        )
-        os.close(pdf_report_fd)
+        report_file_fd, pdf_report_path = tempfile.mkstemp(suffix='.pdf', prefix='report.inherited.tmp.')
+        with closing(os.fdopen(report_file_fd, 'wb')) as report_file:
+            report_file.write(pdf_content)
         temporary_files.append(pdf_report_path)
-        try:
-            wkhtmltopdf = (
-                [_get_wkhtmltopdf_bin()]
-                + command_args
-                + files_command_args
-                + paths
-                + [pdf_report_path]
-            )
-            process = subprocess.Popen(
-                wkhtmltopdf, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-            )
-            out, err = process.communicate()
 
-            if process.returncode not in [0, 1]:
-                if process.returncode == -11:
-                    message = _(
-                        "Wkhtmltopdf failed (error code: %s). Memory limit too low or "
-                        "maximum file number of subprocess reached. Message : %s"
-                    )
-                else:
-                    message = _("Wkhtmltopdf failed (error code: %s). Message: %s")
-                _logger.warning(message, process.returncode, err[-1000:])
-                raise UserError(message % (str(process.returncode), err[-1000:]))
-            else:
-                if err:
-                    _logger.warning("wkhtmltopdf: %s" % err)
+        try:
             # Dynamic Type.
-            if (
-                self
-                and self.custom_report_background
-                and self.custom_report_type == "dynamic"
-            ):
+            if (self and self.custom_report_background and self.custom_report_type == "dynamic"):
                 temp_report_id, temp_report_path = tempfile.mkstemp(
                     suffix=".pdf", prefix="with_back_report.tmp."
                 )

--- a/custom_background/models/report.py
+++ b/custom_background/models/report.py
@@ -216,6 +216,17 @@ class IrActionsReport(models.Model):
         custom_background = custom_bg_lang[:1].background_pdf
         return custom_background
 
+    def _build_wkhtmltopdf_args(
+        self, paperformat_id, landscape, specific_paperformat_args=None, set_viewport_size=False
+    ):
+        command_args = super()._build_wkhtmltopdf_args(
+            paperformat_id, landscape,
+            specific_paperformat_args=specific_paperformat_args,
+            set_viewport_size=set_viewport_size,
+        )
+        command_args.extend(['--print-media-type'])
+        return command_args
+
     @api.model
     def _run_wkhtmltopdf(
         self, bodies, header=None, footer=None, landscape=False,

--- a/custom_background/static/src/scss/report_qweb_pdf.scss
+++ b/custom_background/static/src/scss/report_qweb_pdf.scss
@@ -1,3 +1,5 @@
-body {
-    background: transparent !important;
+@media print {
+    body {
+        background: transparent !important;
+    }
 }


### PR DESCRIPTION
As it is just post-processing of the PDF generated by Odoo Core, we convert `pdf_content` to a file and write it again to the temp directory and proceed as done before without needlessly overriding the whole method.

Info: @wt-io-it